### PR TITLE
needed for intersecting transformed shapes

### DIFF
--- a/lib/Matrix2D.js
+++ b/lib/Matrix2D.js
@@ -11,7 +11,7 @@
  *  [a c e]
  *  [b d f]
  *  [0 0 1]  
- *
+ * 
  *  @param {Number} a
  *  @param {Number} b
  *  @param {Number} c
@@ -73,6 +73,7 @@ function Matrix2D(a, b, c, d, e, f) {
  *  @returns {Matrix2D}
  */
 Matrix2D.IDENTITY = new Matrix2D(1, 0, 0, 1, 0, 0);
+Matrix2D.IDENTITY.isIdentity = function () { return true; };
 
 // TODO: rotate, skew, etc. matrices as well?
 
@@ -82,7 +83,11 @@ Matrix2D.IDENTITY = new Matrix2D(1, 0, 0, 1, 0, 0);
  *  @pararm {Matrix2D} that
  *  @returns {Matrix2D}
  */
-Matrix2D.prototype.multiply = function(that) {
+Matrix2D.prototype.multiply = function (that) {
+    if (this.isIdentity())
+        return that;
+    if (that.isIdentity())
+        return this;
     return new Matrix2D(
         this.a * that.a + this.c * that.b,
         this.b * that.a + this.d * that.b,
@@ -98,7 +103,10 @@ Matrix2D.prototype.multiply = function(that) {
  *
  *  @returns {Matrix2D}
  */
-Matrix2D.prototype.inverse = function() {
+Matrix2D.prototype.inverse = function () {
+    if (this.isIdentity())
+        return this;
+
     var det1 = this.a * this.d - this.b * this.c;
 
     if ( det1 == 0.0 )

--- a/lib/Matrix2D.js
+++ b/lib/Matrix2D.js
@@ -386,6 +386,46 @@ Matrix2D.prototype.getScale = function() {
     };
 };
 
+///////////////////////////////////////////////////////////////////
+/** 
+    Calculates matrix Singular Value Decomposition. <br/>
+    Result are matrices T, R, S, R0 which multiplication gives this matrix.
+    T - translation matrix
+    R - rotation matrix
+    S - scale matrix
+    R0 - rotation matrix
+
+    @see Jim Blinn's article {@link http://dx.doi.org/10.1109/38.486688}
+    @see {@link http://math.stackexchange.com/questions/861674/decompose-a-2d-arbitrary-transform-into-only-scaling-and-rotation}
+   
+    @returns {{ T: Matrix2D, R: Matrix2D, S: Matrix2D, R0: Matrix2D }}
+*/
+Matrix2D.prototype.getDecompositionTRSR = function () {
+    var m00 = this.a;
+    var m10 = this.b;
+    var m01 = this.c;
+    var m11 = this.d;
+    var E = (m00 + m11) / 2;
+    var F = (m00 - m11) / 2;
+    var G = (m10 + m01) / 2;
+    var H = (m10 - m01) / 2;
+    var Q = Math.sqrt(E * E + H * H);
+    var R = Math.sqrt(F * F + G * G);
+    var sx = Q + R;
+    var sy = Q - R;
+    var a1 = Math.atan2(G, F);
+    var a2 = Math.atan2(H, E);
+    var theta = (a2 - a1) / 2;
+    var phi = (a2 + a1) / 2;
+
+    return {
+        T: new Matrix2D(1, 0, 0, 1, this.e, this.f),
+        R: Matrix2D.IDENTITY.rotate(phi),
+        S: new Matrix2D(sx, 0, 0, sy, 0, 0),
+        R0: Matrix2D.IDENTITY.rotate(theta)
+    };
+};
+
 /**
  *  equals
  *

--- a/lib/Matrix2D.js
+++ b/lib/Matrix2D.js
@@ -8,6 +8,9 @@
 
 /**
  *  Matrix2D
+ *  [a c e]
+ *  [b d f]
+ *  [0 0 1]  
  *
  *  @param {Number} a
  *  @param {Number} b


### PR DESCRIPTION
- Singular Value Decomposition is needed for matrix operations used in transformed ellipse/ellipse intersections (so for path's arcs too)
- identity matrix checks are optional, but can be useful if significant amount of intersecting shapes is not transformed, so costly computations (multiplications) can be avoided. It's not much, but saves some CPU cycles.
