### PR TITLE
Make point, vector, and matrix extensible

### DIFF
--- a/lib/Matrix2D.js
+++ b/lib/Matrix2D.js
@@ -92,7 +92,7 @@ Matrix2D.prototype.multiply = function (that) {
         return this;
     }
 
-    return new Matrix2D(
+    return new this.constructor(
         this.a * that.a + this.c * that.b,
         this.b * that.a + this.d * that.b,
         this.a * that.c + this.c * that.d,
@@ -122,7 +122,7 @@ Matrix2D.prototype.inverse = function () {
     var det2 = this.f * this.c - this.e * this.d;
     var det3 = this.e * this.b - this.f * this.a;
 
-    return new Matrix2D(
+    return new this.constructor(
         this.d * idet,
        -this.b * idet,
        -this.c * idet,
@@ -140,7 +140,7 @@ Matrix2D.prototype.inverse = function () {
  *  @returns {Matrix2D}
  */
 Matrix2D.prototype.translate = function(tx, ty) {
-    return new Matrix2D(
+    return new this.constructor(
         this.a,
         this.b,
         this.c,
@@ -157,7 +157,7 @@ Matrix2D.prototype.translate = function(tx, ty) {
  *  @returns {Matrix2D}
  */
 Matrix2D.prototype.scale = function(scale) {
-    return new Matrix2D(
+    return new this.constructor(
         this.a * scale,
         this.b * scale,
         this.c * scale,
@@ -178,7 +178,7 @@ Matrix2D.prototype.scaleAt = function(scale, center) {
     var dx = center.x - scale * center.x;
     var dy = center.y - scale * center.y;
 
-    return new Matrix2D(
+    return new this.constructor(
         this.a * scale,
         this.b * scale,
         this.c * scale,
@@ -196,7 +196,7 @@ Matrix2D.prototype.scaleAt = function(scale, center) {
  *  @returns {Matrix2D}
  */
 Matrix2D.prototype.scaleNonUniform = function(scaleX, scaleY) {
-    return new Matrix2D(
+    return new this.constructor(
         this.a * scaleX,
         this.b * scaleX,
         this.c * scaleY,
@@ -218,7 +218,7 @@ Matrix2D.prototype.scaleNonUniformAt = function(scaleX, scaleY, center) {
     var dx = center.x - scaleX * center.x;
     var dy = center.y - scaleY * center.y;
 
-    return new Matrix2D(
+    return new this.constructor(
         this.a * scaleX,
         this.b * scaleX,
         this.c * scaleY,
@@ -238,7 +238,7 @@ Matrix2D.prototype.rotate = function(radians) {
     var c = Math.cos(radians);
     var s = Math.sin(radians);
 
-    return new Matrix2D(
+    return new this.constructor(
         this.a *  c + this.c * s,
         this.b *  c + this.d * s,
         this.a * -s + this.c * c,
@@ -261,7 +261,7 @@ Matrix2D.prototype.rotateAt = function(radians, center) {
     var t1 = -center.x + center.x * c - center.y * s;
     var t2 = -center.y + center.y * c + center.x * s;
 
-    return new Matrix2D(
+    return new this.constructor(
         this.a *  c + this.c * s,
         this.b *  c + this.d * s,
         this.a * -s + this.c * c,
@@ -282,7 +282,7 @@ Matrix2D.prototype.rotateFromVector = function(vector) {
     var c = unit.x; // cos
     var s = unit.y; // sin
 
-    return new Matrix2D(
+    return new this.constructor(
         this.a *  c + this.c * s,
         this.b *  c + this.d * s,
         this.a * -s + this.c * c,
@@ -298,7 +298,7 @@ Matrix2D.prototype.rotateFromVector = function(vector) {
  *  @returns {Matrix2D}
  */
 Matrix2D.prototype.flipX = function() {
-    return new Matrix2D(
+    return new this.constructor(
         -this.a,
         -this.b,
          this.c,
@@ -314,7 +314,7 @@ Matrix2D.prototype.flipX = function() {
  *  @returns {Matrix2D}
  */
 Matrix2D.prototype.flipY = function() {
-    return new Matrix2D(
+    return new this.constructor(
          this.a,
          this.b,
         -this.c,
@@ -333,7 +333,7 @@ Matrix2D.prototype.flipY = function() {
 Matrix2D.prototype.skewX = function(radians) {
     var t = Math.tan(radians);
 
-    return new Matrix2D(
+    return new this.constructor(
         this.a,
         this.b,
         this.a * t + this.c,
@@ -354,7 +354,7 @@ Matrix2D.prototype.skewX = function(radians) {
 Matrix2D.prototype.skewY = function(radians) {
     var t = Math.tan(radians);
 
-    return new Matrix2D(
+    return new this.constructor(
         this.a + this.c * t,
         this.b + this.d * t,
         this.c,
@@ -436,10 +436,10 @@ Matrix2D.prototype.getDecompositionTRSR = function () {
     var phi = (a2 + a1) / 2;
 
     return {
-        T: new Matrix2D(1, 0, 0, 1, this.e, this.f),
-        R: Matrix2D.IDENTITY.rotate(phi),
-        S: new Matrix2D(sx, 0, 0, sy, 0, 0),
-        R0: Matrix2D.IDENTITY.rotate(theta)
+        T: new this.constructor(1, 0, 0, 1, this.e, this.f),
+        R: this.constructor.IDENTITY.rotate(phi),
+        S: new this.constructor(sx, 0, 0, sy, 0, 0),
+        R0: this.constructor.IDENTITY.rotate(theta)
     };
 };
 

--- a/lib/Point2D.js
+++ b/lib/Point2D.js
@@ -38,7 +38,7 @@ function Point2D(x, y) {
  *  @returns {Point2D}
  */
 Point2D.prototype.clone = function() {
-    return new Point2D(this.x, this.y);
+    return new this.constructor(this.x, this.y);
 };
 
 /**
@@ -48,7 +48,7 @@ Point2D.prototype.clone = function() {
  *  @returns {Point2D}
  */
 Point2D.prototype.add = function(that) {
-    return new Point2D(this.x+that.x, this.y+that.y);
+    return new this.constructor(this.x+that.x, this.y+that.y);
 };
 
 /**
@@ -58,7 +58,7 @@ Point2D.prototype.add = function(that) {
  *  @returns {Point2D}
  */
 Point2D.prototype.subtract = function(that) {
-    return new Point2D(this.x-that.x, this.y-that.y);
+    return new this.constructor(this.x-that.x, this.y-that.y);
 };
 
 /**
@@ -68,7 +68,7 @@ Point2D.prototype.subtract = function(that) {
  *  @returns {Point2D}
  */
 Point2D.prototype.multiply = function(scalar) {
-    return new Point2D(this.x*scalar, this.y*scalar);
+    return new this.constructor(this.x*scalar, this.y*scalar);
 };
 
 /**
@@ -78,7 +78,7 @@ Point2D.prototype.multiply = function(scalar) {
  *  @returns {Point2D}
  */
 Point2D.prototype.divide = function(scalar) {
-    return new Point2D(this.x/scalar, this.y/scalar);
+    return new this.constructor(this.x/scalar, this.y/scalar);
 };
 
 /**
@@ -103,7 +103,7 @@ Point2D.prototype.equals = function(that) {
 Point2D.prototype.lerp = function(that, t) {
     var omt = 1.0 - t;
 
-    return new Point2D(
+    return new this.constructor(
         this.x * omt + that.x * t,
         this.y * omt + that.y * t
     );
@@ -129,7 +129,7 @@ Point2D.prototype.distanceFrom = function(that) {
  *  @returns {Number}
  */
 Point2D.prototype.min = function(that) {
-    return new Point2D(
+    return new this.constructor(
         Math.min( this.x, that.x ),
         Math.min( this.y, that.y )
     );
@@ -142,7 +142,7 @@ Point2D.prototype.min = function(that) {
  *  @returns {Number}
  */
 Point2D.prototype.max = function(that) {
-    return new Point2D(
+    return new this.constructor(
         Math.max( this.x, that.x ),
         Math.max( this.y, that.y )
     );
@@ -155,7 +155,7 @@ Point2D.prototype.max = function(that) {
  *  @result {Point2D}
  */
 Point2D.prototype.transform = function(matrix) {
-    return new Point2D(
+    return new this.constructor(
         matrix.a * this.x + matrix.c * this.y + matrix.e,
         matrix.b * this.x + matrix.d * this.y + matrix.f
     );

--- a/lib/Vector2D.js
+++ b/lib/Vector2D.js
@@ -40,7 +40,7 @@ function Vector2D(x, y) {
  *  @returns {Vector2D}
  */
 Vector2D.fromPoints = function(p1, p2) {
-    return new Vector2D(
+    return new this.constructor(
         p2.x - p1.x,
         p2.y - p1.y
     );
@@ -110,7 +110,7 @@ Vector2D.prototype.unit = function() {
  *  @returns {Vector2D}
  */
 Vector2D.prototype.add = function(that) {
-    return new Vector2D(this.x + that.x, this.y + that.y);
+    return new this.constructor(this.x + that.x, this.y + that.y);
 };
 
 /**
@@ -120,7 +120,7 @@ Vector2D.prototype.add = function(that) {
  *  @returns {Vector2D}
  */
 Vector2D.prototype.subtract = function(that) {
-    return new Vector2D(this.x - that.x, this.y - that.y);
+    return new this.constructor(this.x - that.x, this.y - that.y);
 };
 
 /**
@@ -130,7 +130,7 @@ Vector2D.prototype.subtract = function(that) {
  *  @returns {Vector2D}
  */
 Vector2D.prototype.multiply = function(scalar) {
-    return new Vector2D(this.x * scalar, this.y * scalar);
+    return new this.constructor(this.x * scalar, this.y * scalar);
 };
 
 /**
@@ -140,7 +140,7 @@ Vector2D.prototype.multiply = function(scalar) {
  *  @returns {Vector2D}
  */
 Vector2D.prototype.divide = function(scalar) {
-    return new Vector2D(this.x / scalar, this.y / scalar);
+    return new this.constructor(this.x / scalar, this.y / scalar);
 };
 
 /**
@@ -163,7 +163,7 @@ Vector2D.prototype.angleBetween = function(that) {
  *  @returns {Vector2D}
  */
 Vector2D.prototype.perp = function() {
-    return new Vector2D(-this.y, this.x);
+    return new this.constructor(-this.y, this.x);
 };
 
 /**
@@ -196,7 +196,7 @@ Vector2D.prototype.project = function(that) {
  *  @returns {Vector2D}
  */
 Vector2D.prototype.transform = function(matrix) {
-    return new Vector2D(
+    return new this.constructor(
         matrix.a * this.x + matrix.c * this.y,
         matrix.b * this.x + matrix.d * this.y
     );

--- a/test/point_tests.js
+++ b/test/point_tests.js
@@ -162,7 +162,7 @@ exports.rotateTransform = function(beforeExit, assert) {
 
 exports.rotateFromVectorTransform = function(beforeExit, assert) {
     var p1 = new Point2D(10, 0);
-    var v = new Vector2D(Math.PI / 4.0, Math.PI / 4.0)
+    var v = new Vector2D(Math.PI / 4.0, Math.PI / 4.0);
     var m = new Matrix2D().rotateFromVector(v);
     var p2 = p1.transform(m);
 


### PR DESCRIPTION
This is a PR for #3 and updates point, vector, and matrix operations to create new instances using this.constructor rather than direct constructor references. All tests are passing with this change. One caveat is some matrix methods rely on the constructor's IDENTITY property, so subtypes need to add an IDENTITY property to their constructors for those methods to work. This is less than ideal but acceptable IMHO. I spent a little time thinking about alternative solutions, but nothing came to mind that would fit within the scope of this PR.

Thanks!
