### PR TITLE
fix(Matrix2D): fix uglify error

### DIFF
--- a/lib/Matrix2D.js
+++ b/lib/Matrix2D.js
@@ -19,7 +19,7 @@ function setReadonlyProperty(object, property, value) {
  *  @returns {Matrix2D}
  */
 setReadonlyProperty(Matrix2D, "IDENTITY", new Matrix2D(1, 0, 0, 1, 0, 0));
-setReadonlyProperty(Matrix2D.IDENTITY, "isIdentity", () => true);
+setReadonlyProperty(Matrix2D.IDENTITY, "isIdentity", function () { return true; });
 
 
 /**


### PR DESCRIPTION
The arrow function will cause uglify to throw an error: 
> SyntaxError: Unexpected token: punc ())

This change is introduced in 2.0.3.
If we insist using latest ES syntax, which is strongly encouraging anyhow, I suggest we introduce babel to maintain compatibility with uglifyjs.