### PR TITLE
Typedefs for typescript

### DIFF
--- a/lib/Point2D.js
+++ b/lib/Point2D.js
@@ -130,7 +130,7 @@ class Point2D {
      *  min
      *
      *  @param {module:kld-affine.Point2D} that
-     *  @returns {number}
+     *  @returns {module:kld-affine.Point2D}
      */
     min(that) {
         return new this.constructor(
@@ -143,7 +143,7 @@ class Point2D {
      *  max
      *
      *  @param {module:kld-affine.Point2D} that
-     *  @returns {number}
+     *  @returns {module:kld-affine.Point2D}
      */
     max(that) {
         return new this.constructor(

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "opn-cli": "^4.1.0",
     "rollup": "^1.11.3",
     "rollup-plugin-babel": "^4.3.2",
-    "rollup-plugin-terser": "^4.0.4"
+    "rollup-plugin-terser": "^4.0.4",
+    "typescript": "^3.4.5"
   },
   "engines": {
     "node": ">= 10.15.3"

--- a/package.json
+++ b/package.json
@@ -60,10 +60,10 @@
     "opn-cli": "^4.1.0",
     "rollup": "^1.11.3",
     "rollup-plugin-babel": "^4.3.2",
-    "rollup-plugin-terser": "^4.0.4",
-    "typescript": "^3.4.5"
+    "rollup-plugin-terser": "^4.0.4"
   },
   "engines": {
     "node": ">= 10.15.3"
-  }
+  },
+  "types": "./types/index.d.ts"
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,6 +3,8 @@ declare module 'kld-affine' {
     x: number
     y: number
 
+    constructor (x: number, y: number)
+
     clone (): Point2D
 
     add (that: Point2D): Point2D
@@ -33,6 +35,8 @@ declare module 'kld-affine' {
   class Vector2D {
     x: number
     y: number
+
+    constructor (x: number, y: number)
 
     fromPoint(p1: Point2D, p2: Point2D): Vector2D
 
@@ -80,6 +84,8 @@ declare module 'kld-affine' {
     d: number
     e: number
     f: number
+
+    constructor (a: number, b: number, c: number, d: number, e: number, f: number)
 
     static IDENTITY: Matrix2D
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,154 @@
+declare module 'kld-affine' {
+  class Point2D {
+    x: number
+    y: number
+
+    clone (): Point2D
+
+    add (that: Point2D): Point2D
+
+    subtract (that: Point2D): Point2D
+
+    multiply (scalar: number): Point2D
+
+    divide (scalar: number): Point2D
+
+    equals (that: Point2D): boolean
+
+    precisionEquals (that: Point2D, precision: number): boolean
+
+    lerp (that: Point2D, t: number): Point2D
+
+    distanceFrom (that: Point2D): number
+
+    min (that: Point2D): Point2D
+
+    max (that: Point2D): Point2D
+
+    transform (matrix: Matrix2D): Point2D
+
+    toString (): string
+  }
+
+  class Vector2D {
+    x: number
+    y: number
+
+    fromPoint(p1: Point2D, p2: Point2D): Vector2D
+
+    length (): number
+
+    magnitude (): number
+
+    dot (that: Vector2D): number
+
+    cross (that: Vector2D): number
+
+    determinant (that: Vector2D): number
+
+    unit (): Vector2D
+
+    add (that: Vector2D): Vector2D
+
+    subtract (that: Vector2D): Vector2D
+
+    multiply (scalar: number): Vector2D
+
+    divide (scalar: number): Vector2D
+
+    angleBetween (that: Vector2D): number
+
+    perp (): Vector2D
+
+    perpendicular (that: Vector2D): Vector2D
+
+    project (that: Vector2D): Vector2D
+
+    transform (matrix: Matrix2D): Vector2D
+
+    equals (that: Vector2D): boolean
+
+    precisionEquals(that: Vector2D, precision: number): boolean
+
+    toString (): string
+  }
+
+  class Matrix2D {
+    a: number
+    b: number
+    c: number
+    d: number
+    e: number
+    f: number
+
+    static IDENTITY: Matrix2D
+
+    static translation (tx: number, ty: number): Matrix2D
+
+    static scaling (scale: number): Matrix2D
+
+    static scalingAt (scale: number, center: Point2D): Matrix2D
+
+    static nonUniformScaling (scaleX: number, scaleY: number): Matrix2D
+
+    static nonUniformScalingAt (scaleX: number, scalyY: number, center: Point2D): Matrix2D
+
+    static rotation (radians: number): Matrix2D
+
+    static rotationAt (radians: number, center: Point2D): Matrix2D
+
+    static rotationFromVector (vector: Vector2D): Matrix2D
+
+    static xFlip (): Matrix2D
+
+    static yFlip (): Matrix2D
+
+    static xSkew (radians: number): Matrix2D
+
+    static ySkew (radians: number): Matrix2D
+
+    multiply (that: Matrix2D): Matrix2D
+
+    inverse (): Matrix2D
+
+    translate (tx: number, ty: number): Matrix2D
+
+    scale (scale: number): Matrix2D
+
+    scaleAt (scale: number, center: Point2D): Matrix2D
+
+    scaleNonUniform (scaleX: number, scaleY: number): Matrix2D
+
+    scaleNonUniformAt (scaleX: number, scaleY: number, center: Point2D): Matrix2D
+
+    rotate (radians: number): Matrix2D
+
+    rotateAt (radians: number, center: Point2D): Matrix2D
+
+    rotateFromVector (vector: number): Matrix2D
+
+    flipX (): Matrix2D
+
+    flipY (): Matrix2D
+
+    skewX (radians: number): Matrix2D
+
+    skewY (radians: number): Matrix2D
+
+    isIndentity (): boolean
+
+    isInvertible (): boolean
+
+    getScale (): { scaleX: number, scaleY: number }
+
+    getDecomposition (): { translation: Matrix2D, rotation: Matrix2D, scale: Matrix2D, rotation0: Matrix2D }
+
+    equals (that: Matrix2D): boolean
+
+    precisionEquals (that: Matrix2D, precision: number): boolean
+
+    toString (): string
+  }
+
+
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,7 +3,7 @@ declare module 'kld-affine' {
     x: number
     y: number
 
-    constructor (x: number, y: number)
+    constructor (x: number = 0, y: number = 0)
 
     clone (): Point2D
 
@@ -36,9 +36,9 @@ declare module 'kld-affine' {
     x: number
     y: number
 
-    constructor (x: number, y: number)
+    constructor (x: number = 0, y: number = 0)
 
-    fromPoint(p1: Point2D, p2: Point2D): Vector2D
+    static fromPoints(p1: Point2D, p2: Point2D): Vector2D
 
     length (): number
 
@@ -85,7 +85,14 @@ declare module 'kld-affine' {
     e: number
     f: number
 
-    constructor (a: number, b: number, c: number, d: number, e: number, f: number)
+    constructor (
+      a: number = 1,
+      b: number = 0,
+      c: number = 0,
+      d: number = 1,
+      e: number = 0,
+      f: number = 0
+    )
 
     static IDENTITY: Matrix2D
 


### PR DESCRIPTION
create module kld-affine for typescript, this allows to include it into a typescript project with correct without additional type definitions or an external @types module to include.
I also removed devDependecy of typescript because I can't find a use of it.
Fixed a return type in jsdoc comment for Point2D.min and Point2D.max.